### PR TITLE
redis pool, session 생성 방식 Factory로 수정

### DIFF
--- a/app/common/di.py
+++ b/app/common/di.py
@@ -12,7 +12,7 @@ from app.domain.unsubscriber.repository import UnsubscriberRedisRepository
 
 
 class AppContainer(containers.DeclarativeContainer):
-    redis_connection_pool = providers.Resource(
+    redis_connection_pool = providers.Factory(
         BlockingConnectionPool,
         host=settings.REDIS_URL,
         port=settings.REDIS_PORT,
@@ -21,7 +21,7 @@ class AppContainer(containers.DeclarativeContainer):
         max_connections=30,
         timeout=None,
     )
-    redis_session = providers.Resource(Redis, connection_pool=redis_connection_pool)
+    redis_session = providers.Factory(Redis, connection_pool=redis_connection_pool)
 
     proxy_repository = providers.Singleton(ProxyRedisRepository, session=redis_session)
     proxy_service = providers.Singleton(ProxyService, proxy_repo=proxy_repository)

--- a/app/domain/task/schemas.py
+++ b/app/domain/task/schemas.py
@@ -4,6 +4,7 @@ from fastapi import status
 from pydantic import BaseModel, validator
 
 from app.common.exceptions import APIException
+from app.common.schemas import BaseResponse
 
 
 @dataclass(frozen=True)
@@ -22,3 +23,7 @@ class TaskAddRequest(BaseModel):
         if not values:
             raise APIException(code=status.HTTP_400_BAD_REQUEST, message="올바르지 않은 요청입니다. (subscribers)")
         return values
+
+
+class TaskAddResponse(BaseResponse):
+    node_servers_count: int

--- a/app/router/task.py
+++ b/app/router/task.py
@@ -3,9 +3,8 @@ from fastapi import APIRouter, Depends, status
 
 from app.common.di import AppContainer
 from app.common.exceptions import APIException
-from app.common.schemas import BaseResponse
 from app.domain.node.service import NodeService
-from app.domain.task.schemas import TaskAddRequest
+from app.domain.task.schemas import TaskAddRequest, TaskAddResponse
 from app.domain.task.service import TaskService
 from app.router.node import provide_node_service
 
@@ -20,10 +19,10 @@ async def add_task(
     request: TaskAddRequest,
     task_service: TaskService = Depends(provide_task_service),
     node_service: NodeService = Depends(provide_node_service),
-) -> BaseResponse:
+) -> TaskAddResponse:
     active_nodes = await node_service.get_active_nodes()
     if not active_nodes:
         raise APIException(code=status.HTTP_409_CONFLICT, message="활성화 노드가 존재하지 않습니다.")
 
     await task_service.add_task(request.subscribers, request.message, active_nodes)
-    return BaseResponse()
+    return TaskAddResponse(node_servers_count=len(active_nodes))


### PR DESCRIPTION
- create_task에서 singleton으로 provide 된 redis session 사용시에 블로킹 이슈가 있어서 factory 방식으로 수정 (헬스체크 기능에서 이슈)
- task 추가 응답, 활성화 노드 서버 수 필드 추가(https://github.com/wakscord/wnm_v2/pull/4/commits/4752cbf261f2d81c42f68e8447b0a24f5e9028c9)