### PR TITLE
Proxy API, http 붙여주도록 수정

### DIFF
--- a/app/domain/proxy/repository.py
+++ b/app/domain/proxy/repository.py
@@ -31,10 +31,14 @@ class ProxyRedisRepository(ProxyRepository):
         return await self._session.zrange(self._PROXIES_KEY, start=0, end=-1, withscores=True)
 
     async def add_proxy(self, proxy: str) -> None:
-        await self._session.zadd(self._PROXIES_KEY, mapping={proxy: 0})
+        await self._session.zadd(self._PROXIES_KEY, mapping={self._to_http(proxy): 0})
 
     async def add_proxies(self, proxies: list[str]) -> None:
-        await self._session.zadd(self._PROXIES_KEY, mapping={proxy: 0 for proxy in proxies})
+        await self._session.zadd(self._PROXIES_KEY, mapping={self._to_http(proxy): 0 for proxy in proxies})
 
     async def delete_proxy(self, proxy: str) -> None:
-        await self._session.zrem(self._PROXIES_KEY, proxy)
+        await self._session.zrem(self._PROXIES_KEY, self._to_http(proxy))
+
+    @staticmethod
+    def _to_http(proxy_url: str) -> str:
+        return f"http://{proxy_url}"

--- a/tests/unit/test_task.py
+++ b/tests/unit/test_task.py
@@ -1,0 +1,11 @@
+from app.domain.task.service import TaskService
+
+
+def test_chunked_subscribers_is_equal_node_length():
+    # given
+    subscribers = [i for i in range(8)]
+    nodes_len = 6
+    # when
+    chunked_subscribers = TaskService._chunk_subscribers(subscribers, nodes_len)
+    # then
+    assert len(chunked_subscribers) == nodes_len


### PR DESCRIPTION
- proxy 삭제 및 추가시 앞에 `http://` 붙여주도록 수정 (https 필요할 경우 추후에 수정)
- 구독자 chunk 테스트 추가